### PR TITLE
Build and publish images to Github Container Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '42 17 * * *'
+  push:
+    branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        with:
+          cosign-release: 'v2.1.1'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,12 +6,8 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '42 17 * * *'
   push:
     branches: [ "main" ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
 
@@ -19,11 +15,14 @@ env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: kktse/cfdof-openfoam
 
 
 jobs:
   build:
+    strategy:
+      matrix:
+        distribution: ["foundation", "opencfd"]
 
     runs-on: ubuntu-latest
     permissions:
@@ -76,8 +75,9 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
+          build-args: "TARGET=${{ matrix.distribution }}"
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ matrix.distribution }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -95,4 +95,4 @@ jobs:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        run: echo "${{ matrix.distribution }}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ pulls the latest Foundation and OpenCFD/ESI versions of OpenFOAM from Docker
 Hub, configures the environment for compatibility with CfdOF, and installs `gmsh`,
 `cfmesh` and `hisa`.
 
-At the time of writing, CfdOF 1.25.13 supports OpenFOAM Foundations versions 9
-through 10, and OpenCFD/ESI v2006 to v2306.
+At the time of writing, CfdOF 1.25.13 supports OpenFOAM Foundation 9 to 10, and
+OpenCFD/ESI v2006 to v2306.
 
 ## Building manually
 
@@ -32,4 +32,5 @@ clicking "Run dependency checker".
 
 ## Reverting to the default CfdOF Docker image
 
-The default image URL is [`docker.io/mmcker/cfdof-openfoam`](https://hub.docker.com/r/mmcker/cfdof-openfoam).
+The default image URL used by CfdOF is
+[`docker.io/mmcker/cfdof-openfoam`](https://hub.docker.com/r/mmcker/cfdof-openfoam).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ DOCKER_BUILDKIT=1 docker build --build-arg="TARGET=foundation" -f dockerfile .
 $ docker build --build-arg="TARGET=foundation" -f dockerfile .
 ```
 
-You can pick between `foundation` and `opencfd` builds of OpenFOAM. These correspond to the following images and versions:
+You can configure the build with the `TARGET` argument. The `TARGET` argument can be set to `foundation` and `opencfd`. These correspond to the following images and versions:
 
 - foundation: [`openfoam/openfoam10-paraview56:10`](https://hub.docker.com/r/openfoam/openfoam10-paraview510)
 - opencfd: [`opencfd/openfoam-default:2306`](https://hub.docker.com/r/opencfd/openfoam-default)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ DOCKER_BUILDKIT=1 docker build --build-arg="TARGET=foundation" -f dockerfile .
 $ docker build --build-arg="TARGET=foundation" -f dockerfile .
 ```
 
-You can configure the build with the `TARGET` argument. The `TARGET` argument can be set to `foundation` and `opencfd`. These correspond to the following images and versions:
+You can configure the build with the `TARGET` argument. The `TARGET` argument can be set to `foundation` and `opencfd`. These correspond to the following images and versions of OpenFOAM:
 
 - foundation: [`openfoam/openfoam10-paraview56:10`](https://hub.docker.com/r/openfoam/openfoam10-paraview510)
 - opencfd: [`opencfd/openfoam-default:2306`](https://hub.docker.com/r/opencfd/openfoam-default)


### PR DESCRIPTION
Adds a Github Action to build and push pre-built images to Github Container Registry. This allows general consumption of the modified Docker images for anyone wishing to use OpenFOAM Foundation 10 or OpenCFD/ESI v2306 with CfdOF. This is advantageous due to the portability and cross-platform compatibility of Docker.

## Implementation notes

Images are tagged as `kktse/cfdof-openfoam` to match the naming scheme of the default OpenFOAM v9 image supplied by CfdOF. 

At this time, only two tags are supplied: `opencfd` and `foundation`.

Consequently, there is no versioning associated with these images. Older versions of OpenFOAM beyond Foundation 10 and OpenCFD/ESI v2306 are not considered.

## Followups

* Update README.md with instructions to use pre-built images
  * Would like to have the images pushed before I write these instructions
  * Would also like to test those images