### PR TITLE
Override tag naming in build and publish action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
           context: .
           build-args: "TARGET=${{ matrix.distribution }}"
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ matrix.distribution }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.distribution }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The `docker/build-publish-action` expects a list of tags with the full image name, including the registry URL, image name, and tag. Because there are only two options for tagging, this had been overridden as `${{ matrix.distribution }}` to correspond to the `foundation` and `opencfd` tags, as desired.

This has the side effect of defaulting to Docker Hub as the image registry, which is unintended. This passes in the full image name as a tag and hopefully allow the image to be pushed to ghcr.