### PR TITLE
Use cfmesh from opencfd distribution

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,14 +27,14 @@ on:
         description: Upstream OpenFOAM Docker image reference
         required: true
         type: string
-      runtime_user:
-        description: Final container user
+      dockerfile:
+        description: Edition-specific Dockerfile to build
         required: true
-        default: openfoam
+        default: dockerfile.opencfd
         type: choice
         options:
-          - openfoam
-          - root
+          - dockerfile.foundation
+          - dockerfile.opencfd
       update_alias:
         description: Also update the moving edition alias tag
         required: true
@@ -55,13 +55,13 @@ jobs:
         include:
           - distribution: foundation
             version: "11"
+            dockerfile: dockerfile.foundation
             base_image: openfoam/openfoam11-paraview510:11
-            runtime_user: openfoam
             latest: true
           - distribution: opencfd
             version: "2512"
+            dockerfile: dockerfile.opencfd
             base_image: opencfd/openfoam-dev:2512
-            runtime_user: root
             latest: true
 
     runs-on: ubuntu-latest
@@ -116,9 +116,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
-            RUNTIME_USER=${{ matrix.runtime_user }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -185,9 +185,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ${{ inputs.dockerfile }}
           build-args: |
             BASE_IMAGE=${{ inputs.base_image }}
-            RUNTIME_USER=${{ inputs.runtime_user }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenCFD/ESI versions of OpenFOAM from Docker Hub, install `gmsh`, `cfmesh` and
 `hisa`, and configure a bashrc script to work with CfdOF.
 
 At the time of writing, CfdOF 1.37.3 supports OpenFOAM Foundation 9 to 13, and
-OpenCFD/ESI v2206 to v2512.
+OpenCFD/ESI v2006 to v2512.
 
 ## Using pre-built images
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # Unofficial OpenFOAM Docker Images for CfdOF
 
 Unofficial OpenFOAM Docker Images for CfdOF. This lets you to run newer
-versions of OpenFOAM with CfdOF via Docker. The dockerfile pulls the latest
-Foundation and OpenCFD/ESI versions of OpenFOAM from Docker Hub, installs
-`gmsh`, `cfmesh` and `hisa`, and configures a bashrc script to work with CfdOF.
+versions of OpenFOAM with CfdOF via Docker. The Dockerfiles pull Foundation and
+OpenCFD/ESI versions of OpenFOAM from Docker Hub, install `gmsh`, `cfmesh` and
+`hisa`, and configure a bashrc script to work with CfdOF.
 
-At the time of writing, CfdOF 1.25.13 supports OpenFOAM Foundation 9 to 10, and
-OpenCFD/ESI v2006 to v2306.
+At the time of writing, CfdOF 1.37.3 supports OpenFOAM Foundation 9 to 13, and
+OpenCFD/ESI v2206 to v2512.
 
 ## Using pre-built images
 
-Images are built against `dockerfile` and uploaded to GitHub Container Registry
-(GHCR). The latest image tags are provided.
+Images are built against `dockerfile.foundation` and `dockerfile.opencfd` and
+uploaded to GitHub Container Registry
+(GHCR). The edition tags track the latest image configured for that OpenFOAM
+edition.
 
-- OpenFOAM Foundation 10 - `ghcr.io/kktse/cfdof-openfoam:foundation`
-- OpenCFD/ESI v2306 - `ghcr.io/kktse/cfdof-openfoam:opencfd`
+- OpenFOAM Foundation - `ghcr.io/kktse/cfdof-openfoam:foundation`
+- OpenCFD/ESI - `ghcr.io/kktse/cfdof-openfoam:opencfd`
 
-To use the pre-built images with CfdOF pull the desired image from GHCR.
+To use the pre-built images with CfdOF pull the latest image from GHCR.
 
 ```bash
 $ docker pull ghcr.io/kktse/cfdof-openfoam:foundation
@@ -30,34 +32,37 @@ FreeCAD and CfdOF, as it may not download all the necessary image layers.
 In FreeCAD, navigate to the CfdOF preferences page by navigating to Edit >
 Preferences > CfdOf. In the Software dependencies > Docker Container section,
 toggle **Use docker** to true, and specify the **"Download from URL"** path to
-the desired image name. For example, to use the OpenFOAM Foundation 10 image,
+the desired image name. For example, to use the OpenFOAM Foundation image,
 set the "Download from URL" field to `ghcr.io/kktse/cfdof-openfoam:foundation`.
 Proceed as usual to install the Docker container runtime per the [CfdOF
 instructions](cfdof-docker-instructions).
 
 ## Building locally
 
-To build an image manually, pass the same base image and runtime user configured
-in the GitHub Actions build matrix.
+To build an image manually, use the Dockerfile for the OpenFOAM edition you
+want to build.
 
 ```bash
 $ DOCKER_BUILDKIT=1 docker build \
-    --build-arg="BASE_IMAGE=openfoam/openfoam10-paraview56:10" \
-    --build-arg="RUNTIME_USER=openfoam" \
-    -f dockerfile .
+    --build-arg="BASE_IMAGE=openfoam/openfoam11-paraview510:11" \
+    -f dockerfile.foundation .
 # or
 $ DOCKER_BUILDKIT=1 docker build \
-    --build-arg="BASE_IMAGE=opencfd/openfoam-default:2306" \
-    --build-arg="RUNTIME_USER=root" \
-    -f dockerfile .
+    --build-arg="BASE_IMAGE=opencfd/openfoam-dev:2512" \
+    -f dockerfile.opencfd .
 ```
 
 The OpenFOAM versions built by GitHub Actions are defined in the
 `matrix.include` entries in `.github/workflows/docker-publish.yml`. The current
 base images are:
 
-- foundation: [`openfoam/openfoam10-paraview56:10`](https://hub.docker.com/r/openfoam/openfoam10-paraview510)
-- opencfd: [`opencfd/openfoam-default:2306`](https://hub.docker.com/r/opencfd/openfoam-default)
+Foundation builds compile `cfmesh-cfdof` from source. OpenCFD builds use the
+`cartesianMesh` provided by the OpenCFD base image and install a small
+`cartesianMesh -version` compatibility shim for CfdOF.
+
+For Foundation images, set the CfdOF mesh object's number of meshing processes
+to `1`. The parallel cfMesh path can fail during reconstruction with
+`Non-empty processor patch "processor0to1" found in reconstructed mesh`.
 
 Maintainers can also use the manual GitHub Actions workflow trigger to build a
 one-off Foundation or OpenCFD image by supplying the desired version, base image
@@ -84,18 +89,14 @@ toggle **Use docker** to true, and specify the **"Download from URL"** path as
 
 ## Installation sources
 
-Foundation images are based on
-[`openfoam/openfoam10-paraview56:10`](https://hub.docker.com/r/openfoam/openfoam10-paraview510).
-`gmsh` is installed from the Ubuntu Focal 20.04 LTS repositories, which at the
-time of writing is version [4.4.1](https://packages.ubuntu.com/focal/gmsh)
+Foundation and OpenCFD/ESI images are based on the `BASE_IMAGE` selected in
+`.github/workflows/docker-publish.yml` or supplied to the manual workflow.
+`gmsh` is installed from the selected base image's apt repositories.
 
-OpenCFD/ESI images are based on
-[`opencfd/openfoam-default:2306`](https://hub.docker.com/r/opencfd/openfoam-default).
-`gmsh` is installed from the Ubuntu Jammy 22.04 LTS repositories, which at the
-time of writing is version [4.8.4](https://packages.ubuntu.com/jammy/gmsh)
-
-`cfmesh` is compiled from source from
-[cfMesh-CfdOF](https://sourceforge.net/projects/cfmesh-cfdof/).
+For Foundation images, `cfmesh` is compiled from source from
+[cfMesh-CfdOF](https://sourceforge.net/projects/cfmesh-cfdof/). For OpenCFD/ESI
+images, the version of `cartesianMesh` packaged in the base image is used with a
+CfdOF-compatible `-version` shim.
 
 `hisa` is compiled from source from
 [HiSA](https://sourceforge.net/projects/hisa).

--- a/dockerfile.foundation
+++ b/dockerfile.foundation
@@ -1,32 +1,32 @@
-ARG BASE_IMAGE=scratch
+ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS build
 
-ARG RUNTIME_USER="openfoam"
-ENV USER="${RUNTIME_USER}"
+ENV USER="openfoam"
 
 SHELL ["/bin/bash", "-c"]
 
 # Install required packages
 USER root
 RUN apt-get update && \
-    apt-get install -y build-essential python3-pip python-is-python3 unzip gmsh
+    apt-get install -y build-essential ca-certificates python3-pip python-is-python3 unzip wget gmsh && \
+    rm -rf /var/lib/apt/lists/*
 
 # Setup bashrc
 COPY bashrc /etc/bashrc
 
-# Install gmsh
-WORKDIR /home/openfoam
-
-# Install gmsh
+# Install CfdOF's cfMesh fork for Foundation images.
 WORKDIR /home/openfoam
 RUN wget https://sourceforge.net/projects/cfmesh-cfdof/files/cfmesh-cfdof.zip/download -O cfmesh-cfdof.zip && \
     unzip cfmesh-cfdof.zip && \
-    rm cfmesh-cfdof.zip
-WORKDIR /home/openfoam/cfmesh-cfdof
-RUN find . -type f -name Allwmake -exec sed -i 's/wmake/wmake -j/g' {} +;
-RUN source /etc/bashrc && \
-    ./Allwmake
-RUN rm -r /home/openfoam/cfmesh-cfdof 
+    rm cfmesh-cfdof.zip && \
+    cd cfmesh-cfdof && \
+    find . -type f -name Allwmake -exec sed -i 's/wmake/wmake -j/g' {} + && \
+    source /etc/bashrc && \
+    ./Allwmake && \
+    cd /home/openfoam && \
+    rm -r cfmesh-cfdof
+RUN source /etc/bashrc && command -v cartesianMesh && cartesianMesh -version
+
 
 # Install HiSA
 WORKDIR /home/openfoam
@@ -40,4 +40,4 @@ RUN source /etc/bashrc && \
 RUN rm -r /home/openfoam/hisa-master
 
 WORKDIR /home/openfoam
-USER ${RUNTIME_USER}
+USER openfoam

--- a/dockerfile.opencfd
+++ b/dockerfile.opencfd
@@ -1,0 +1,50 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS build
+
+ENV USER="root"
+
+SHELL ["/bin/bash", "-c"]
+
+# Install required packages
+USER root
+RUN apt-get update && \
+    apt-get install -y build-essential ca-certificates python3-pip python-is-python3 unzip wget gmsh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setup bashrc
+COPY bashrc /etc/bashrc
+
+# Use OpenCFD's version-matched cfMesh, but provide a compatible -version flag
+# for CfdOF's dependency check using the real OpenFOAM version.
+WORKDIR /home/openfoam
+RUN source /etc/bashrc && \
+    real_cartesian_mesh="$(command -v cartesianMesh)" && \
+    test "${real_cartesian_mesh}" != /usr/local/bin/cartesianMesh && \
+    printf '%s\n' \
+    '#!/bin/bash' \
+    'if [[ "${1:-}" == "-version" ]]; then' \
+    '    version="${WM_PROJECT_VERSION#v}"' \
+    '    if [[ "${version}" =~ ^[0-9]+$ ]]; then' \
+    '        version="${version}.0"' \
+    '    fi' \
+    '    echo "OpenCFD bundled cfMesh ${version}"' \
+    '    exit 0' \
+    'fi' \
+    "exec \"${real_cartesian_mesh}\" \"\$@\"" \
+    > /usr/local/bin/cartesianMesh && \
+    chmod 755 /usr/local/bin/cartesianMesh
+RUN source /etc/bashrc && command -v cartesianMesh && cartesianMesh -version
+
+# Install HiSA
+WORKDIR /home/openfoam
+RUN wget https://sourceforge.net/projects/hisa/files/hisa-master.zip/download -O hisa-master.zip && \
+    unzip hisa-master.zip && \
+    rm hisa-master.zip
+WORKDIR /home/openfoam/hisa-master
+RUN find . -type f -name Allwmake -exec sed -i 's/wmake/wmake -j/g' {} +;
+RUN source /etc/bashrc && \
+    ./Allwmake
+RUN rm -r /home/openfoam/hisa-master
+
+WORKDIR /home/openfoam
+USER root


### PR DESCRIPTION
## Background

Using the CfdOf forked version of cfmesh causes the mesher to fall over. Use the build-in mesher and provide a version shim for CfdOf compat.

## Discussion

This also splits out the Foundation and OpenCFD images into separate dockerfiles as the build steps are starting to diverge.